### PR TITLE
Refactor devcontainer setup: use Dockerfile for build and update deep…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bullseye
+
+RUN rm -f /etc/apt/sources.list.d/yarn.list

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,10 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
 	"name": "Spec2Win",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+	// Build from a Dockerfile to remove stale apt sources before features install.
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 	"features": {
 		"ghcr.io/devcontainers/features/azure-cli:1": {
 			"installBicep": true,

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -20,7 +20,8 @@
       ]
     },
     "deepwiki": {
-      "url": "https://mcp.deepwiki.com/sse"
+      "type": "http",
+      "url": "https://mcp.deepwiki.com/mcp"
     }
   }
 }


### PR DESCRIPTION
The base image mcr.microsoft.com/devcontainers/python:1-3.12-* ships with a Yarn apt repository (/etc/apt/sources.list.d/yarn.list) whose GPG key (62D54FD4003F6525) is expired. When the docker-in-docker feature runs apt-get update during installation, it fails fatally on this unsigned repo (exit code 100), causing the entire container build to fail and dropping the codespace into recovery mode.
 
Fixes:
- Dockerfile — Created a Dockerfile that extends the base image and removes the stale Yarn apt source before any features install.
- devcontainer.json — Changed "image" to "build": {"dockerfile": "Dockerfile"} so the container builds from the Dockerfile instead of using the base image directly. All features (including docker-in-docker) are preserved.
- Updated the DeepWiki MCP endpoint to use Streamable HTTP instead of deprecated SSE