### PR TITLE
fix(docs): correct agent and prompt counts across all documentation

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -215,8 +215,8 @@ jobs:
             ### 📋 What's Included
             
             **Full Package**:
-            - ✅ 8 specialized AI agents (PM, Dev Lead, Dev, Azure, Rev-Eng, Modernizer, Planner, Architect)
-            - ✅ 13 workflow prompts
+            - ✅ 10 specialized AI agents (Spec2Cloud, PM, Dev Lead, Dev, Azure, Tech Analyst, Modernizer, Extender, Planner, Architect)
+            - ✅ 12 workflow prompts
             - ✅ MCP server configuration
             - ✅ Dev container setup
             - ✅ Installation scripts (Linux/Mac/Windows)
@@ -224,8 +224,8 @@ jobs:
             - ✅ Documentation
             
             **Minimal Package**:
-            - ✅ 8 specialized AI agents
-            - ✅ 13 workflow prompts
+            - ✅ 10 specialized AI agents
+            - ✅ 12 workflow prompts
             
             ### 🔐 Verification
             

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -58,8 +58,8 @@ cd spec2cloud
 ### Full Installation
 
 Includes everything:
-- ✅ 7 specialized AI agents
-- ✅ 13 workflow prompts
+- ✅ 10 specialized AI agents
+- ✅ 12 workflow prompts
 - ✅ MCP server configuration
 - ✅ Dev container setup
 - ✅ APM configuration
@@ -76,8 +76,8 @@ Includes everything:
 ### Minimal Installation
 
 Includes only:
-- ✅ 7 specialized AI agents
-- ✅ 13 workflow prompts
+- ✅ 10 specialized AI agents
+- ✅ 12 workflow prompts
 
 ```bash
 # Linux/Mac
@@ -106,26 +106,28 @@ After installation, your project will have:
 ```
 your-project/
 ├── .github/
-│   ├── agents/              # 7 specialized AI agents
+│   ├── agents/              # 10 specialized AI agents
 │   │   ├── architect.agent.md
 │   │   ├── azure.agent.md
-│   │   ├── dev-lead.agent.md
 │   │   ├── dev.agent.md
+│   │   ├── devlead.agent.md
+│   │   ├── extender.agent.md
 │   │   ├── modernizer.agent.md
+│   │   ├── planner.agent.md
 │   │   ├── pm.agent.md
-│   │   └── rev-eng.agent.md
-│   └── prompts/             # 13 workflow prompts
-│       ├── architect.prompt.md
+│   │   ├── spec2cloud.agent.md
+│   │   └── tech-analyst.agent.md
+│   └── prompts/             # 12 workflow prompts
+│       ├── adr.prompt.md
+│       ├── bootstrap-agents.prompt.md
 │       ├── delegate.prompt.md
 │       ├── deploy.prompt.md
-│       ├── frd-brown.prompt.md
+│       ├── extend.prompt.md
 │       ├── frd.prompt.md
 │       ├── generate-agents.prompt.md
 │       ├── implement.prompt.md
 │       ├── modernize.prompt.md
-│       ├── plan-brown.prompt.md
 │       ├── plan.prompt.md
-│       ├── prd-brown.prompt.md
 │       ├── prd.prompt.md
 │       └── rev-eng.prompt.md
 ├── .vscode/
@@ -360,7 +362,7 @@ ls .github/agents/*.agent.md
 # Check prompts
 ls .github/prompts/*.prompt.md
 
-# Should see 7 agents and 13 prompts
+# Should see 10 agents and 12 prompts
 ```
 
 ## 📊 Verification
@@ -372,8 +374,8 @@ After installation, verify everything is working:
 tree .github/
 
 # 2. Count installed components
-find .github/agents -name "*.agent.md" | wc -l   # Should be 7
-find .github/prompts -name "*.prompt.md" | wc -l  # Should be 13
+find .github/agents -name "*.agent.md" | wc -l   # Should be 10
+find .github/prompts -name "*.prompt.md" | wc -l  # Should be 12
 
 # 3. Open in VS Code
 code .
@@ -382,10 +384,10 @@ code .
 # Press Ctrl+Shift+I (Windows/Linux) or Cmd+Shift+I (Mac)
 
 # 5. Type @ and verify agents appear
-# Should see: @pm, @dev, @dev-lead, @azure, @rev-eng, @modernize, @architect
+# Should see: @spec2cloud, @pm, @devlead, @architect, @planner, @dev, @azure, @tech-analyst, @modernizer, @extender
 
 # 6. Type / and verify prompts appear
-# Should see: /prd, /frd, /plan, /implement, /deploy, /delegate, /rev-eng, /modernize, etc.
+# Should see: /prd, /frd, /plan, /implement, /deploy, /delegate, /rev-eng, /modernize, /extend, /adr, etc.
 ```
 
 ## 🔄 Updating Spec2Cloud

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ code .
 ```
 
 **What Gets Installed**:
-- ✅ 8 specialized AI agents (PM, Dev Lead, Dev, Azure, Rev-Eng, Modernizer, Planner, Architect)
-- ✅ 13 workflow prompts
+- ✅ 10 specialized AI agents (Spec2Cloud, PM, Dev Lead, Dev, Azure, Tech Analyst, Modernizer, Extender, Planner, Architect)
+- ✅ 12 workflow prompts
 - ✅ MCP server configuration (optional)
 - ✅ Dev container setup (optional)
 - ✅ APM configuration (optional)

--- a/templates/RELEASE_README.md
+++ b/templates/RELEASE_README.md
@@ -6,17 +6,19 @@ Transform any project into a spec2cloud-enabled development environment with spe
 
 This package contains:
 
-✅ **8 Specialized AI Agents**
+✅ **10 Specialized AI Agents**
+- Spec2Cloud Orchestrator - Main entry point, delegates to specialized agents
 - PM Agent - Product requirements and feature planning
-- Dev Lead Agent - Technical architecture and standards
-- Dev Agent - Implementation and code generation  
+- Dev Lead Agent - Technical review and feasibility assessment
+- Architect Agent - Standards, guidelines, and AGENTS.md management
+- Planner Agent - Research and multi-step planning (no implementation)
+- Dev Agent - Implementation and code generation
 - Azure Agent - Cloud deployment and infrastructure
-- Reverse Engineering Agent - Codebase documentation
+- Tech Analyst Agent - Reverse engineering and codebase documentation
 - Modernization Agent - Technical debt and upgrades
-- Planner Agent - Task breakdown and planning
-- Architect Agent - System design and patterns
+- Extension Agent - New feature requirements and integration strategies
 
-✅ **13 Workflow Prompts**
+✅ **12 Workflow Prompts**
 - `/prd` - Create Product Requirements Document
 - `/frd` - Create Feature Requirements Documents
 - `/plan` - Create Technical Task Breakdown
@@ -25,11 +27,10 @@ This package contains:
 - `/deploy` - Deploy to Azure
 - `/rev-eng` - Reverse engineer existing codebase
 - `/modernize` - Create modernization plan
+- `/extend` - Plan new feature extensions
 - `/generate-agents` - Generate agent guidelines
-- `/architect` - Design system architecture
-- `/prd-brown` - Generate PRD from existing code
-- `/frd-brown` - Generate FRDs from existing code
-- `/plan-brown` - Generate tasks from existing code
+- `/bootstrap-agents` - Bootstrap agent configurations
+- `/adr` - Create Architecture Decision Records
 
 ✅ **Additional Components** (Full Package Only)
 - MCP server configuration for enhanced AI capabilities
@@ -76,7 +77,7 @@ After installation:
 3. Type `@` to see available agents
 4. Type `/` to see available workflows
 
-You should see all 8 agents and 13 prompts listed.
+You should see all 10 agents and 12 prompts listed.
 
 ## 📖 Usage
 


### PR DESCRIPTION
Updates agent counts from 7/8 to 10 and prompt counts from 13 to 12 across README.md, INTEGRATION.md, templates/RELEASE_README.md, and .github/workflows/package-release.yml. Cross-referenced against actual files on disk.