### PR TITLE
Propose creating mermaid diagrams

### DIFF
--- a/.github/skills/implementation/SKILL.md
+++ b/.github/skills/implementation/SKILL.md
@@ -45,7 +45,7 @@ See `references/api-slice.md`, `references/web-slice.md`, and
 Before writing any code, determine the correct implementation order:
 
 1. Read all Gherkin features, step definitions, and e2e specs. Cross-reference
-   FRDs for dependency declarations.
+   FRDs and `specs/prd.md` for dependency declarations and overall product flow.
 2. Order features so dependencies are satisfied first.
 3. Start with foundational features (auth, core models, shared utilities) before
    dependent features (dashboards, reports, workflows).
@@ -168,6 +168,33 @@ After ALL features pass their integration slices, run the complete suite:
 
 After regression passes, generate documentation: `npm run docs:generate`
 
+## PRD Implementation Diagram Update
+
+After regression passes and before the final implementation handoff, review
+`specs/prd.md`.
+
+Add or update an `## Implementation Diagram` section when the implemented flow
+is non-trivial — for example:
+
+- request/response chains spanning multiple components
+- async workflows, queues, or webhooks
+- cross-layer orchestration that is easier to understand visually
+- critical user flows whose runtime behavior is clearer as a diagram
+
+Use Mermaid text. Prefer:
+
+- `sequenceDiagram` for request, command, and event interactions
+- `flowchart` for branching pipelines
+- `stateDiagram-v2` for lifecycle-driven behavior
+
+Rules:
+
+- Diagram actual as-built behavior, not intended architecture.
+- Keep it consistent with contracts, tests, and the running code.
+- Update only the implementation diagram section; do not rewrite approved
+  product requirements unless the human separately changed scope.
+- If the runtime flow is trivial, the section may remain absent.
+
 ## Fast Feedback Practices
 
 - **Watch mode**: `cd src/api && npm run test:watch` for rapid API iteration.
@@ -240,5 +267,6 @@ The orchestrator MUST verify ALL of the following before marking implementation 
 - [ ] Full regression suite passes (not just tests for the current increment)
 - [ ] No `test.skip()`, `xit()`, `@pending`, or commented-out tests exist in the codebase
 - [ ] State JSON and audit log are updated with per-slice completion
+- [ ] If the implemented flow is non-trivial, `specs/prd.md` includes an up-to-date Mermaid implementation diagram that matches the actual code path
 
 **BLOCKING**: If any item is unchecked, the skill has NOT completed successfully. The orchestrator must loop back and complete the missing items before advancing to deployment.

--- a/.github/skills/prd-generator/SKILL.md
+++ b/.github/skills/prd-generator/SKILL.md
@@ -119,7 +119,25 @@ Using import graphs, call chains, and shared data models:
 4. Record external service dependencies (third-party APIs, databases, message
    queues)
 
-### Step 5: Determine Product Scope
+### Step 5: Generate Diagrams
+
+Generate Mermaid diagrams that make the PRD easier to understand:
+
+1. **Product Flow Diagram** — place this at the top of the PRD when the product
+   has a meaningful workflow, actor handoff, lifecycle, or multi-step process.
+   Prefer:
+   - `flowchart` for business processes
+   - `journey` for end-to-end user journeys
+   - `stateDiagram-v2` for lifecycle/state transitions
+2. **Implementation Diagram** — because brownfield already has working code,
+   include an as-built diagram when the runtime flow is non-trivial. Prefer:
+   - `sequenceDiagram` for request/response or command/event flows
+   - `flowchart` for orchestration or branching pipelines
+
+If a diagram would not materially improve understanding, say so explicitly
+instead of forcing decorative Mermaid.
+
+### Step 6: Determine Product Scope
 
 Categorize everything found into:
 
@@ -135,10 +153,20 @@ This directly maps to the "Out of Scope" section of the PRD.
 
 ### File: `specs/prd.md`
 
-The generated PRD must match the greenfield PRD format exactly:
+The generated PRD must preserve the greenfield PRD's core sections and order,
+with the optional diagram sections described below:
 
 ```markdown
 # Product Requirements Document
+
+## Product Flow Diagram
+
+```mermaid
+{Mermaid diagram that clarifies the product or business process when relevant}
+```
+
+{If no product/process diagram materially improves understanding, state that it
+was intentionally omitted because the flow is trivial.}
 
 ## Product Vision
 
@@ -186,7 +214,17 @@ analysis.}
 ## Out of Scope
 
 {Areas explicitly not implemented. If the app is an e-commerce platform but
-has no recommendation engine, note that here. Derived from Step 5.}
+has no recommendation engine, note that here. Derived from Step 6.}
+
+## Implementation Diagram
+
+```mermaid
+{Mermaid sequence, flow, or state diagram of the current implementation if
+useful}
+```
+
+{If the implementation is too trivial for a diagram, state that it was
+intentionally omitted.}
 
 ## Appendix: Extraction Evidence
 
@@ -206,10 +244,11 @@ locations that informed it. This provides traceability.}
 3. **Never fabricate features.** If a route exists but the handler is empty,
    document it as "Stubbed" — do not describe it as a working feature.
 
-4. **Preserve the greenfield format.** Downstream skills (FRD generator,
-   gherkin generator, increment planner) expect the exact section structure
-   shown above. Do not rename sections, add custom sections outside the
-   template, or change the feature table columns.
+4. **Preserve the greenfield core format.** Downstream skills (FRD generator,
+   gherkin generator, increment planner) expect the core section structure shown
+   above. Do not rename the core sections or change the feature table columns.
+   The only diagram additions are `## Product Flow Diagram` immediately after
+   the title and `## Implementation Diagram` before the appendix when useful.
 
 5. **Include the evidence appendix.** This is the brownfield-specific addition
    that gives reviewers confidence the PRD reflects reality.
@@ -223,6 +262,7 @@ FRD generation begins. Present the PRD with a summary of:
 - Persona count and confidence level
 - Areas where inference was heavy (low confidence sections)
 - Stubbed/incomplete features that may need product decisions
+- Whether the PRD included product and implementation diagrams or explicit omission rationale
 
 The human may:
 - ✅ Approve as-is → proceed to FRD generation
@@ -256,14 +296,16 @@ After human approval, update `status` to `"approved"`.
 Before presenting the PRD for human review:
 
 - [ ] Product Vision is a single, coherent paragraph
+- [ ] The PRD begins with a Mermaid product/process diagram when the workflow is non-trivial, or explicitly explains why a diagram was omitted
 - [ ] Every persona has evidence from the codebase
 - [ ] Every feature has a traceable source (routes, components, services)
 - [ ] Feature priorities reflect actual code completeness, not guesses
 - [ ] Non-functional requirements are extracted from real config, not assumed
 - [ ] Out of Scope section exists (even if minimal)
+- [ ] The PRD includes an as-built implementation diagram when the runtime flow is non-trivial, or explicitly explains why it was omitted
 - [ ] Evidence appendix maps every section to extraction sources
 - [ ] No fabricated features — every entry is backed by code
-- [ ] Format matches greenfield PRD template exactly
+- [ ] Format matches the greenfield PRD core template plus the diagram guidance above
 - [ ] State JSON is updated
 
 **BLOCKING**: If any item is unchecked, the skill has NOT completed successfully. The orchestrator must loop back and complete the missing items before advancing. The PRD is the foundation for all downstream FRDs — gaps here propagate everywhere.

--- a/.github/skills/spec-refinement/SKILL.md
+++ b/.github/skills/spec-refinement/SKILL.md
@@ -58,6 +58,7 @@ You have a maximum of 5 passes per document. Use them wisely.
 - Run the full product lens checklist.
 - Focus on completeness, missing requirements, and user story quality.
 - Identify the biggest gaps first — don't nitpick on pass 1.
+- Check whether a leading Mermaid product/process diagram is needed to make the PRD understandable at a glance.
 
 ### Pass 2 — Technical Lens Deep Dive
 
@@ -90,6 +91,28 @@ You have a maximum of 5 passes per document. Use them wisely.
 - If no critical or major issues remain after a pass, recommend approval.
 - State clearly: "This document is ready to proceed to the next phase."
 - Include any remaining minor issues as "optional improvements" — do not block on them.
+
+## PRD Diagram Standards
+
+When a PRD describes a workflow, actor handoff, lifecycle, state transition, or
+multi-step process, it should begin with a Mermaid diagram immediately after the
+title and before `## Product Vision`.
+
+Prefer diagrams that clarify the product behavior:
+
+- `flowchart` for business processes and decision paths
+- `sequenceDiagram` for actor/system interactions
+- `stateDiagram-v2` for lifecycle or status transitions
+- `journey` for end-to-end user journeys
+
+Treat a missing leading diagram as a **major** issue when the product would
+otherwise be hard to understand from prose alone. If the workflow is genuinely
+trivial, omission is acceptable, but say so explicitly in the review.
+
+After implementation exists, PRDs may also include an `## Implementation
+Diagram` section near the end of the document. Use it for as-built request
+flows, orchestration, async pipelines, or other runtime interactions. Do **not**
+require this section before code exists.
 
 ## PRD → FRD Breakdown Strategy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,9 @@ Phase 2: Increment Delivery   (repeats per increment)
 ### Phase 1: Product Discovery
 
 #### 1a: Spec Refinement → `spec-refinement` skill
-Review PRD/FRDs through product + technical lenses (max 5 passes). Break PRD into FRDs.
+Review PRD/FRDs through product + technical lenses (max 5 passes). If the PRD
+describes a non-trivial workflow, ensure it begins with a Mermaid
+product/process diagram. Break PRD into FRDs.
 **Exit:** Human approves all FRDs. **Human gate:** Yes.
 
 #### 1b: UI/UX Design → `ui-ux-design` skill
@@ -254,7 +256,9 @@ API contracts, shared TypeScript types, infrastructure requirements. No human ga
 **Commit:** `[increment] {id}/contracts — contracts generated`
 
 #### Step 3: Implementation → `implementation` skill
-API slice → Web slice (parallel) → Integration slice (sequential). Full regression.
+API slice → Web slice (parallel) → Integration slice (sequential). Full
+regression. If the runtime flow is non-trivial, update `specs/prd.md` with an
+as-built Mermaid implementation diagram before PR review.
 **Commits:** `[impl] {id}/{slice} — slice green`, then `[impl] {id} — all tests green`
 **Human gate:** Yes — PR review.
 

--- a/docs/brownfield.md
+++ b/docs/brownfield.md
@@ -41,7 +41,7 @@ Six extraction skills scan the codebase without making any judgments:
 
 Two generators create formal specifications from the extraction output:
 
-- **PRD Generator** — Product Requirements Document reverse-engineered from the codebase (**Human Gate**)
+- **PRD Generator** — Product Requirements Document reverse-engineered from the codebase, including a top Mermaid product/process diagram when relevant and an as-built implementation diagram when useful (**Human Gate**)
 - **FRD Generator** — Feature Requirement Documents with "Current Implementation" sections (**Human Gate**)
 - **Spec Refinement** — Review through product + technical lenses (**Human Gate**)
 

--- a/docs/examples/greenfield-walkthrough.md
+++ b/docs/examples/greenfield-walkthrough.md
@@ -31,7 +31,11 @@ You get: Next.js + Express + Playwright + Cucumber + Vitest + Bicep — all pre-
 
 ## Step 1: Write Your PRD (~20 min)
 
-This is the only step where you write anything substantial. Open `specs/prd.md` and describe your Task Board — what it does, who uses it, what the key user stories are, and any constraints (in-memory, no auth).
+This is the only step where you write anything substantial. Open `specs/prd.md`
+and describe your Task Board — what it does, who uses it, what the key user
+stories are, and any constraints (in-memory, no auth). If the workflow is
+non-trivial, start the PRD with a Mermaid process or journey diagram before the
+written sections.
 
 > **Why this matters:** Your PRD is the ground truth everything traces back to. The more deliberately you write it, the more meaningful the verification is at every downstream gate. Vague requirements lead to passing tests that don't actually prove anything.
 
@@ -109,6 +113,10 @@ Three slices run:
 | **Integration** | API + Web running together, full regression green |
 
 > **💡 Try it live:** Aspire is already running in the background. Ask the agent for the Aspire dashboard URL and open your app in the browser. Click around, test the flows, and see if anything feels off. If you spot bugs or issues, ask the agent to fix them — it can use the Aspire and Playwright MCP tools to diagnose and resolve problems interactively. It's much cheaper to catch issues here than after deployment.
+
+If the runtime flow is easier to understand visually, ask the agent to update
+`specs/prd.md` with an as-built Mermaid implementation diagram before you do the
+implementation review.
 
 🚦 **Human Gate — implementation verification:** Review the diff. Does this match what you approved in the Gherkin? Tests passing is necessary — but not sufficient. You're verifying the *right* implementation, not just a green one.
 

--- a/docs/greenfield.md
+++ b/docs/greenfield.md
@@ -23,6 +23,9 @@ Before Phase 0 exits, all scaffolding must be verified: `specs/` directory, `.sp
 
 Your PRD is reviewed through product and technical lenses. Up to 5 refinement passes ensure completeness: edge cases, feasibility, clarity. The PRD is then broken into individual FRDs (Feature Requirement Documents).
 
+If the product has a meaningful workflow or lifecycle, the approved PRD should
+start with a Mermaid product/process diagram before the prose sections.
+
 **Human Gate:** Review and approve refined PRD and FRDs before proceeding.
 
 ### 1b — UI/UX Design
@@ -81,6 +84,10 @@ Three parallel slices:
 - **Integration Slice**: Wire API + Web together (tested with Cucumber + Playwright e2e)
 
 API and Web run in parallel. Integration is sequential after both complete. Red baseline tests turn green.
+
+If the implemented runtime flow is non-trivial, update `specs/prd.md` with an
+as-built Mermaid implementation diagram (often a sequence diagram) before the
+PR review gate.
 
 **Human Gate:** PR review before deployment.
 

--- a/docs/shells.md
+++ b/docs/shells.md
@@ -54,7 +54,7 @@ The 46 skills are stack-agnostic. Shells provide the stack-specific wiring (whic
 
 1. Run the installer with a shell: `npx spec2cloud init --shell <id>`
 2. Open in VS Code with the dev container
-3. Write your PRD in `specs/prd.md`
+3. Write your PRD in `specs/prd.md`, starting with a Mermaid product/process diagram when it clarifies the workflow
 4. Start with `/prd` in Copilot Chat
 
 ## Adding to an Existing Project


### PR DESCRIPTION
Humans have an easier time to review when provided with context.
Marmaid diagrams (sequence, classes, etc) can help understand what needs to be done, and reduce missunderstanding between LLMs and the requirements.
This PR proposes to ask the LLM to create diagrams for every PRD, both for the business process and for the technical implementation. 